### PR TITLE
Add support for retained releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To be successfully used in a workflow, this actions requires the client to
 | `sha` | A git SHA (e.g. `main`) identifying your target build. This input is optional, but one of either `gitref` or `sha` must be passed to this action. If both are given, then `sha` takes precedence over `gitref` | `string`, **optional** |
 | `github-token` | Token used to authenticate git operations, such as `fetch` and `tag`. Usually passsing `${{ secrets.GITHUB_TOKEN }}` is the desired setup | `string`, **required** |
 | `console-credentials` | The JSON credentials for the service account to use in deployment | `string`, **required** |
-| `version-codes-to-retain` | Version codes already uploaded to retain in this release. Used for supporting older Android versions. Comma seperated list of version code integers | `string`, **optional**, default: (empty string) |
+| `version-codes-to-retain` | Version codes already uploaded to retain in this release. Used for supporting older Android versions. Comma separated list of version code integers | `string`, **optional**, default: (empty string) |
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To be successfully used in a workflow, this actions requires the client to
 | `sha` | A git SHA (e.g. `main`) identifying your target build. This input is optional, but one of either `gitref` or `sha` must be passed to this action. If both are given, then `sha` takes precedence over `gitref` | `string`, **optional** |
 | `github-token` | Token used to authenticate git operations, such as `fetch` and `tag`. Usually passsing `${{ secrets.GITHUB_TOKEN }}` is the desired setup | `string`, **required** |
 | `console-credentials` | The JSON credentials for the service account to use in deployment | `string`, **required** |
+| `version-codes-to-retain` | Version codes already uploaded to retain in this release. Used for supporting older Android versions. Comma seperated list of version code integers | `string`, **optional**, default: (empty string) |
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -65,12 +65,6 @@ runs:
         echo "DRY_RUN=${{ inputs.dry-run == 'true' && 'echo' || '' }}" >> $GITHUB_ENV
         echo "VERSION_CODES_TO_RETAIN=${{ inputs.version-codes-to-retain }}" >> $GITHUB_ENV
 
-    - name: "Set version_codes_to_retain param"
-      shell: bash
-      if: ${{ inputs.version-codes-to-retain != '' }}
-      run: |
-          echo "VERSION_CODES_TO_RETAIN_PARAM='--version_codes_to_retain ${{ inputs.version-codes-to-retain }}'" >> $GITHUB_ENV
-
     - name: Determinate target sha if not given to action
       shell: bash
       if: env.SHA == ''
@@ -111,7 +105,7 @@ runs:
           --aab_path *.aab \
           --skip_upload_apk \
           --rollout ${{ env.ROLLOUT }} \
-          ${VERSION_CODES_TO_RETAIN_PARAM}
+          ${VERSION_CODES_TO_RETAIN:+--version_codes_to_retain $VERSION_CODES_TO_RETAIN}
       env:
         SUPPLY_JSON_KEY_DATA: ${{ inputs.console-credentials }}
         SUPPLY_UPLOAD_MAX_RETRIES: 1

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
     console-credentials:
       required: true
       type: string
-    version_codes_to_retain:
+    version-codes-to-retain:
       required: false
       type: string
       default: '[]'
@@ -63,7 +63,7 @@ runs:
         echo "SHA=${{ inputs.sha }}" >> $GITHUB_ENV
         # if inputs.dry-run is true, then we set env.DRY_RUN to echo, otherwise we set it to empty string
         echo "DRY_RUN=${{ inputs.dry-run == 'true' && 'echo' || '' }}" >> $GITHUB_ENV
-        echo "VERSION_CODES_TO_RETAIN=${{ inputs.version_codes_to_retain }}" >> $GITHUB_ENV
+        echo "VERSION_CODES_TO_RETAIN=${{ inputs.version-codes-to-retain }}" >> $GITHUB_ENV
 
     - name: Determinate target sha if not given to action
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
         # if inputs.dry-run is true, then we set env.DRY_RUN to echo, otherwise we set it to empty string
         echo "DRY_RUN=${{ inputs.dry-run == 'true' && 'echo' || '' }}" >> $GITHUB_ENV
         echo "VERSION_CODES_TO_RETAIN=${{ inputs.version-codes-to-retain }}" >> $GITHUB_ENV
-        echo "VERSION_CODES_TO_RETAIN_PARAM='--version_codes_to_retain ${{ inputs.version-codes-to-retain }}'" >> $GITHUB_ENV
+        echo "VERSION_CODES_TO_RETAIN_PARAM=${{ inputs.version-codes-to-retain == '' && '' || '--version_codes_to_retain $VERSION_CODES_TO_RETAIN' }}
 
     - name: Determinate target sha if not given to action
       shell: bash
@@ -106,7 +106,7 @@ runs:
           --aab_path *.aab \
           --skip_upload_apk \
           --rollout ${{ env.ROLLOUT }} \
-          ${{ env.VERSION_CODES_TO_RETAIN != '' && '--version_codes_to_retain ' env.VERSION_CODES_TO_RETAIN || ''}}
+          ${VERSION_CODES_TO_RETAIN_PARAM}
       env:
         SUPPLY_JSON_KEY_DATA: ${{ inputs.console-credentials }}
         SUPPLY_UPLOAD_MAX_RETRIES: 1

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
     console-credentials:
      required: true
      type: string
+    version_codes_to_retain:
+      required: false
+      type: string
+      default: '[]'
 outputs:
   aab:
     description: "The filename of the aab that was deployed"
@@ -59,6 +63,7 @@ runs:
         echo "SHA=${{ inputs.sha }}" >> $GITHUB_ENV
         # if inputs.dry-run is true, then we set env.DRY_RUN to echo, otherwise we set it to empty string
         echo "DRY_RUN=${{ inputs.dry-run == 'true' && 'echo' || '' }}" >> $GITHUB_ENV
+        echo "VERSION_CODES_TO_RETAIN=${{ inputs.version_codes_to_retain }}" >> $GITHUB_ENV
 
     - name: Determinate target sha if not given to action
       shell: bash
@@ -89,6 +94,7 @@ runs:
         echo "**aab**: $(ls *.aab)" >> $GITHUB_STEP_SUMMARY
         echo "aab=$(ls *.aab)" >> $GITHUB_OUTPUT
         echo "sha=${{ env.SHA }}" >> $GITHUB_OUTPUT
+        echo "version_codes_to_retain=${{ env.VERSION_CODES_TO_RETAIN }}" >> $GITHUB_OUTPUT
 
     - name: Release ${{ env.ARTIFACT_NAME }} build to ${{ env.ROLLOUT }} of ${{ env.TRACK}} track from ${{ env.GITREF }}@${{ env.SHA }}
       shell: bash
@@ -98,6 +104,7 @@ runs:
           --track ${{ env.TRACK}} \
           --aab_path *.aab \
           --skip_upload_apk \
+          --version_codes_to_retain ${{ VERSION_CODES_TO_RETAIN }}
           --rollout ${{ env.ROLLOUT }}
       env:
         SUPPLY_JSON_KEY_DATA: ${{ inputs.console-credentials }}

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
     version-codes-to-retain:
       required: false
       type: string
-      default: '[]'
+      default: ''
 outputs:
   aab:
     description: "The filename of the aab that was deployed"
@@ -64,6 +64,7 @@ runs:
         # if inputs.dry-run is true, then we set env.DRY_RUN to echo, otherwise we set it to empty string
         echo "DRY_RUN=${{ inputs.dry-run == 'true' && 'echo' || '' }}" >> $GITHUB_ENV
         echo "VERSION_CODES_TO_RETAIN=${{ inputs.version-codes-to-retain }}" >> $GITHUB_ENV
+        echo "VERSION_CODES_TO_RETAIN_PARAM='--version_codes_to_retain ${{ inputs.version-codes-to-retain }}'" >> $GITHUB_ENV
 
     - name: Determinate target sha if not given to action
       shell: bash
@@ -104,8 +105,8 @@ runs:
           --track ${{ env.TRACK}} \
           --aab_path *.aab \
           --skip_upload_apk \
-          --version_codes_to_retain ${{ env.VERSION_CODES_TO_RETAIN }} \
-          --rollout ${{ env.ROLLOUT }}
+          --rollout ${{ env.ROLLOUT }} \
+          ${{ env.VERSION_CODES_TO_RETAIN != '' && '--version_codes_to_retain ' env.VERSION_CODES_TO_RETAIN || ''}}
       env:
         SUPPLY_JSON_KEY_DATA: ${{ inputs.console-credentials }}
         SUPPLY_UPLOAD_MAX_RETRIES: 1

--- a/action.yml
+++ b/action.yml
@@ -33,11 +33,11 @@ inputs:
       required: false
       type: string
     github-token:
-     required: true
-     type: string
+      required: true
+      type: string
     console-credentials:
-     required: true
-     type: string
+      required: true
+      type: string
     version_codes_to_retain:
       required: false
       type: string
@@ -104,7 +104,7 @@ runs:
           --track ${{ env.TRACK}} \
           --aab_path *.aab \
           --skip_upload_apk \
-          --version_codes_to_retain ${{ env.VERSION_CODES_TO_RETAIN }}
+          --version_codes_to_retain ${{ env.VERSION_CODES_TO_RETAIN }} \
           --rollout ${{ env.ROLLOUT }}
       env:
         SUPPLY_JSON_KEY_DATA: ${{ inputs.console-credentials }}

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,12 @@ runs:
         # if inputs.dry-run is true, then we set env.DRY_RUN to echo, otherwise we set it to empty string
         echo "DRY_RUN=${{ inputs.dry-run == 'true' && 'echo' || '' }}" >> $GITHUB_ENV
         echo "VERSION_CODES_TO_RETAIN=${{ inputs.version-codes-to-retain }}" >> $GITHUB_ENV
-        echo "VERSION_CODES_TO_RETAIN_PARAM=${{ inputs.version-codes-to-retain == '' && '' || '--version_codes_to_retain $VERSION_CODES_TO_RETAIN' }}
+
+    - name: "Set version_codes_to_retain param"
+      shell: bash
+      if: ${{ inputs.version-codes-to-retain != '' }}
+      run: |
+          echo "VERSION_CODES_TO_RETAIN_PARAM='--version_codes_to_retain ${{ inputs.version-codes-to-retain }}'" >> $GITHUB_ENV
 
     - name: Determinate target sha if not given to action
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
           --track ${{ env.TRACK}} \
           --aab_path *.aab \
           --skip_upload_apk \
-          --version_codes_to_retain ${{ VERSION_CODES_TO_RETAIN }}
+          --version_codes_to_retain ${{ env.VERSION_CODES_TO_RETAIN }}
           --rollout ${{ env.ROLLOUT }}
       env:
         SUPPLY_JSON_KEY_DATA: ${{ inputs.console-credentials }}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds input parameter version-codes-to-retain

This is to maintain support for older versions of Android.

All new builds of the Android news app that we release require Android 10 and above. 
However users on Android 8 can still download app version 20846 from the Play Store, and users on Android 9 can still download version 21373

For production builds on the news app  version-codes-to-retain will be set to 20846,21373

For all other apps and tracks (feast and news internal / beta) it will be set to empty string.

If it's not provided we don't pass the parameter to the fastlane supply command.

## How to test
Dry run of an internal release where the parameter is not passed https://github.com/guardian/android-news-app/actions/runs/15538993345/job/43744931519#step:3:162

Dry run of a production release where the parameter is passed https://github.com/guardian/android-news-app/actions/runs/15538900720/job/43744615265#step:3:164

## How can we measure success?

We don't have to do manual production releases any more.

